### PR TITLE
Defragment the free list

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Build project
         run: cd build && cmake --build .
       - name: Run tests
-        run: cd build && ctest .
+        run: cd build && ctest . --verbose

--- a/include/realtime_memory/utilities.h
+++ b/include/realtime_memory/utilities.h
@@ -12,7 +12,7 @@ namespace cradle::pmr
  *   - `compare_nodes_fn` should take two `list_node` pointers and
  *     return true if the first should be before the second in the list.
  *
- *  This is probably the fastest  way of sorting a singly linked list
+ *  This is probably the fastest way of sorting a singly linked list
  *  without allocating auxiliary memory.
  *
  *  Inspired by this public-domain pseudocode:

--- a/include/realtime_memory/utilities.h
+++ b/include/realtime_memory/utilities.h
@@ -1,0 +1,95 @@
+//==============================================================================
+// Copyright (c) 2019-2022 CradleApps, LLC - All Rights Reserved
+//==============================================================================
+/** Utility functions for the  */
+#pragma once
+#include <utility>
+
+namespace cradle::pmr
+{
+
+/** Merge sort a singly linked list.
+ *   - `list_node` must have a `next` pointer.
+ *   - `compare_nodes_fn` should take two `list_node` pointers and
+ *     return true if the first should be before the second in the list.
+ *
+ *  This is probably the fastest a sort of a singly linked list
+ *  can be without allocating auxiliary memory.
+ *
+ *  Inspired by this public-domain pseudocode:
+ *  https://www.chiark.greenend.org.uk/~sgtatham/algorithms/listsort.html
+ */
+template <typename list_node, typename compare_nodes_fn>
+list_node* merge_sort_list (list_node* list, compare_nodes_fn&& compare)
+{
+    if (list == nullptr)
+        return nullptr;
+
+    int chunk_size = 1;
+
+    while (true)
+    {
+        list_node* p = std::exchange (list, nullptr);
+        list_node* tail = nullptr;
+        int num_merges = 0;
+
+        while (p != nullptr)
+        {
+            ++num_merges;
+
+            list_node* q = p;
+            int q_size = chunk_size;
+            int p_size = 0;
+
+            for (int i = 0; i < chunk_size; ++i)
+            {
+                ++p_size;
+                q = q->next;
+
+                if (q == nullptr)
+                    break;
+            }
+
+            list_node* next = nullptr;
+
+            // merge the two lists, choosing nodes from p or q as appropriate.
+            while (p_size > 0 || (q_size > 0 && q != nullptr))
+            {
+                if (p_size != 0 && (q_size == 0 || q == nullptr || compare (p, q)))
+                {
+                    next = p;
+                    p = p->next;
+                    --p_size;
+                }
+                else
+                {
+                    next = q;
+                    q = q->next;
+                    --q_size;
+                }
+
+                // add the next node to the merged list
+                if (tail == nullptr)
+                    list = next;
+                else
+                    tail->next = next;
+
+                tail = next;
+            }
+
+            // both p and q have stepped `chunk_size' places along
+            p = q;
+        }
+
+        tail->next = nullptr;
+
+        // If we have done only one merge, we're finished.
+        if (num_merges <= 1) // could be 0 if p is empty
+            return list;
+
+        // Otherwise repeat, merging lists twice the size
+        chunk_size *= 2;
+    }
+}
+
+}

--- a/include/realtime_memory/utilities.h
+++ b/include/realtime_memory/utilities.h
@@ -1,7 +1,6 @@
 //==============================================================================
-// Copyright (c) 2019-2022 CradleApps, LLC - All Rights Reserved
+// Copyright (c) 2019-2023 CradleApps, LLC - All Rights Reserved
 //==============================================================================
-/** Utility functions for the  */
 #pragma once
 #include <utility>
 
@@ -13,8 +12,8 @@ namespace cradle::pmr
  *   - `compare_nodes_fn` should take two `list_node` pointers and
  *     return true if the first should be before the second in the list.
  *
- *  This is probably the fastest a sort of a singly linked list
- *  can be without allocating auxiliary memory.
+ *  This is probably the fastest  way of sorting a singly linked list
+ *  without allocating auxiliary memory.
  *
  *  Inspired by this public-domain pseudocode:
  *  https://www.chiark.greenend.org.uk/~sgtatham/algorithms/listsort.html

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,7 +12,8 @@ FetchContent_MakeAvailable(Catch2)
 add_executable(realtime_memory_tests
   main.cpp
   resource_tests.cpp;
-  allocator_tests.cpp)
+  allocator_tests.cpp;
+  utilities_tests.cpp)
 target_link_libraries(realtime_memory_tests PRIVATE
   realtime_memory
   Catch2::Catch2WithMain)

--- a/tests/allocator_tests.cpp
+++ b/tests/allocator_tests.cpp
@@ -1,8 +1,5 @@
 //==============================================================================
-// Copyright (c) 2019-2022 CradleApps, LLC - All Rights Reserved
-//
-// This file is part of the Cradle Engine. Unauthorised copying and
-// redistribution is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2019-2023 CradleApps, LLC - All Rights Reserved
 //==============================================================================
 
 #include <catch2/catch_test_macros.hpp>

--- a/tests/resource_tests.cpp
+++ b/tests/resource_tests.cpp
@@ -423,10 +423,8 @@ TEST_CASE ("free_list_resource", "[memory_resource]")
         // Return all the blocks except one in the middle.
         // We do this in random order, to ensure the the free list must be sorted.
         const auto middlePtr = ptrs[ptrs.size() / 2];
-        const auto permutation = Catch::Generators::random (0ul, ptrs.size()).get();
-
-        for (std::size_t i = 0; i < permutation; ++i)
-            std::next_permutation (ptrs.begin(), ptrs.end());
+        const auto seed = Catch::Generators::Detail::getSeed();
+        std::shuffle (ptrs.begin(), ptrs.end(), std::default_random_engine (seed));
 
         for (auto p : ptrs)
             if (p != middlePtr)

--- a/tests/resource_tests.cpp
+++ b/tests/resource_tests.cpp
@@ -1,8 +1,5 @@
 //==============================================================================
-// Copyright (c) 2019-2022 CradleApps, LLC - All Rights Reserved
-//
-// This file is part of the Cradle Engine. Unauthorised copying and
-// redistribution is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2019-2023 CradleApps, LLC - All Rights Reserved
 //==============================================================================
 
 #include <unordered_set>

--- a/tests/resource_tests.cpp
+++ b/tests/resource_tests.cpp
@@ -426,7 +426,7 @@ TEST_CASE ("free_list_resource", "[memory_resource]")
         // Return all the blocks except one in the middle.
         // We do this in random order, to ensure the the free list must be sorted.
         const auto middlePtr = ptrs[ptrs.size() / 2];
-        const auto permutation = Catch::Generators::random (0ul, ptrs.size()).next();
+        const auto permutation = Catch::Generators::random (0ul, ptrs.size()).get();
 
         for (std::size_t i = 0; i < permutation; ++i)
             std::next_permutation (ptrs.begin(), ptrs.end());

--- a/tests/resource_tests.cpp
+++ b/tests/resource_tests.cpp
@@ -423,10 +423,17 @@ TEST_CASE ("free_list_resource", "[memory_resource]")
         catch (const std::bad_alloc&)
         {}
 
-        // Return all the blocks except one in the middle
-        for (std::size_t i = 0; i < ptrs.size(); ++i)
-            if (i != ptrs.size() / 2)
-                res.deallocate (ptrs[i], smallBlockSize, alignment);
+        // Return all the blocks except one in the middle.
+        // We do this in random order, to ensure the the free list must be sorted.
+        const auto middlePtr = ptrs[ptrs.size() / 2];
+        const auto permutation = Catch::Generators::random (0ul, ptrs.size()).next();
+
+        for (std::size_t i = 0; i < permutation; ++i)
+            std::next_permutation (ptrs.begin(), ptrs.end());
+
+        for (auto p : ptrs)
+            if (p != middlePtr)
+                res.deallocate (p, smallBlockSize, alignment);
 
         // Check that the two areas either side of the still-active pointer
         // can be re-merged in a defragmentation step.

--- a/tests/utilities_tests.cpp
+++ b/tests/utilities_tests.cpp
@@ -1,0 +1,84 @@
+//==============================================================================
+// Copyright (c) 2019-2022 CradleApps, LLC - All Rights Reserved
+//
+// This file is part of the Cradle Engine. Unauthorised copying and
+// redistribution is strictly prohibited. Proprietary and confidential.
+//==============================================================================
+
+#include "realtime_memory/utilities.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/generators/catch_generators_random.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
+
+//==============================================================================
+TEST_CASE ("merge sort linked lists")
+{
+    struct node
+    {
+        node* next = nullptr;
+        int data = 0;
+
+        explicit node (int d) : data (d) {}
+    };
+
+    const int listLength = 1000;
+    auto rand = Catch::Generators::random<int> (0, 100000);
+
+    // Build the list
+    auto head = new node (rand.get());
+    auto current = head;
+
+    for (int i = 0; i < listLength; ++i, rand.next())
+    {
+        current->next = new node (rand.get());
+        current = current->next;
+    }
+
+    const auto lowestFirst  = [] (node* a, node* b) { return a->data < b->data; };
+    const auto highestFirst = [] (node* a, node* b) { return a->data > b->data; };
+
+    SECTION ("Sort lowest first")
+    {
+        head = cradle::pmr::merge_sort_list (head, lowestFirst);
+
+        int numInList = 0;
+        int numSorted = 0;
+
+        for (auto n = head; n != nullptr && n->next != nullptr; n = n->next)
+        {
+            numSorted += n->data <= n->next->data ? 1 : 0;
+            ++numInList;
+        }
+
+        CHECK (numInList == listLength);
+        CHECK (numSorted == listLength);
+    }
+
+    SECTION ("Sort highest first")
+    {
+        head = cradle::pmr::merge_sort_list (head, highestFirst);
+
+        int numInList = 0;
+        int numSorted = 0;
+
+        for (auto n = head; n != nullptr && n->next != nullptr; n = n->next)
+        {
+            numSorted += n->data >= n->next->data ? 1 : 0;
+            ++numInList;
+        }
+
+        CHECK (numInList == listLength);
+        CHECK (numSorted == listLength);
+    }
+
+    // Free the list
+    while (head != nullptr)
+    {
+        auto next = head->next;
+        delete head;
+        head = next;
+    }
+}


### PR DESCRIPTION
This allows blocks that are returned to the list to be re-merged, meaning a future request for a large block is more likely to succeed.