### PR TITLE
Ignore apple clang depreciated

### DIFF
--- a/include/realtime_memory/memory_resources.h
+++ b/include/realtime_memory/memory_resources.h
@@ -316,10 +316,7 @@ namespace detail
     inline std::size_t mono_default_nextbuf_size = 32 * sizeof(void*);
     inline std::size_t max_u32 = (std::size_t) std::numeric_limits<std::uint32_t>::max();
 
-    inline pool_options default_pool_options = {
-        .max_blocks_per_chunk = std::size_t (1 << 15),
-        .largest_required_pool_block = 4096
-    };
+    inline pool_options default_pool_options = {std::size_t (1 << 15), 4096};
 
     // Note: Undefined behaviour if 'align' is not a power of two!
     constexpr std::size_t aligned_ceil (size_t size, size_t align) noexcept

--- a/include/realtime_memory/memory_resources.h
+++ b/include/realtime_memory/memory_resources.h
@@ -4,6 +4,8 @@
 #pragma once
 #include "pmr_includes.h"
 
+PMR_DIAGNOSTIC_PUSH
+
 //==============================================================================
 namespace cradle::pmr
 {
@@ -627,3 +629,5 @@ inline bool unsynchronized_pool_resource::is_oversized (std::size_t bytes, std::
 }
 
 } // namespace cradle::pmr
+
+PMR_DIAGNOSTIC_POP

--- a/include/realtime_memory/pmr_includes.h
+++ b/include/realtime_memory/pmr_includes.h
@@ -3,10 +3,29 @@
 #include <cassert>
 #include <vector>
 
-#if defined(__clang__)
+#if defined (__apple_build_version__)
+ #define USE_EXPERIMENTAL_PMR __apple_build_version__ < 15000000 || __MAC_OS_X_VERSION_MIN_REQUIRED < 140000
+#elif defined (__clang__)
+ #define USE_EXPERIMENTAL_PMR _LIBCPP_VERSION < 1600
+#else
+ #define USE_EXPERIMENTAL_PMR 0
+#endif
+
+#if USE_EXPERIMENTAL_PMR
  #include <experimental/memory_resource>
  namespace std_pmr = std::experimental::pmr;
 #else
  #include <memory_resource>
  namespace std_pmr = std::pmr;
+#endif
+
+#if defined (__apple_build_version__) && USE_EXPERIMENTAL_PMR
+ #define PMR_DIAGNOSTIC_PUSH \
+  _Pragma("clang diagnostic push") \
+  _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+ #define PMR_DIAGNOSTIC_POP \
+  _Pragma("clang diagnostic pop")
+#else
+ #define PMR_DIAGNOSTIC_PUSH
+ #define PMR_DIAGNOSTIC_POP
 #endif

--- a/include/realtime_memory/polymorphic_allocators.h
+++ b/include/realtime_memory/polymorphic_allocators.h
@@ -6,6 +6,8 @@
 #include "pmr_includes.h"
 #include "memory_resources.h"
 
+PMR_DIAGNOSTIC_PUSH
+
 namespace cradle::pmr
 {
 /** A simple alias would trigger 'undefined symbols for get_default_resource()' on ARM. */
@@ -115,3 +117,5 @@ bool operator!= (const propagating_allocator<ValueType1>& alloc1,
 }
 
 } // cradle::pmr
+
+PMR_DIAGNOSTIC_POP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,3 +17,9 @@ add_executable(realtime_memory_tests
 target_link_libraries(realtime_memory_tests PRIVATE
   realtime_memory
   Catch2::Catch2WithMain)
+
+if(MSVC)
+    target_compile_options(realtime_memory_tests PRIVATE /W4 /WX)
+else()
+    target_compile_options(realtime_memory_tests PRIVATE -Wall -Wextra -Wpedantic -Werror)
+endif()

--- a/tests/resource_tests.cpp
+++ b/tests/resource_tests.cpp
@@ -261,10 +261,7 @@ TEST_CASE ("unsynchronized_pool_resource", "[memory_resource]")
         const auto largestBlock = GENERATE (as<size_t>(), 32ul, 1 << 15, max_u64 - 1);
         CAPTURE (maxBlocks, largestBlock);
 
-        pmr::pool_options options {
-            .max_blocks_per_chunk = maxBlocks,
-            .largest_required_pool_block = largestBlock
-        };
+        pmr::pool_options options {maxBlocks, largestBlock};
         pmr::unsynchronized_pool_resource pool (options, nullptr);
 
         const auto expectedLargestBlock = std::min (largestBlock, max_u32);
@@ -424,7 +421,7 @@ TEST_CASE ("free_list_resource", "[memory_resource]")
         {}
 
         // Return all the blocks except one in the middle.
-        // We do this in random order, to ensure the the free list must be sorted.
+        // We do this in random order, to ensure the free list must be sorted.
         const auto middlePtr = ptrs[ptrs.size() / 2];
         const auto seed = Catch::Generators::Detail::getSeed();
         std::shuffle (ptrs.begin(), ptrs.end(), std::default_random_engine (seed));

--- a/tests/resource_tests.cpp
+++ b/tests/resource_tests.cpp
@@ -9,6 +9,8 @@
 #include "realtime_memory/free_list_resource.h"
 #include "realtime_memory/containers.h"
 
+PMR_DIAGNOSTIC_PUSH
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
@@ -16,6 +18,7 @@
 #include <catch2/generators/catch_generators_range.hpp>
 
 //==============================================================================
+
 /** To track the allocations farmed out to a memory_resource's "upstream". */
 class tracking_memory_resource : public std_pmr::memory_resource
 {
@@ -765,3 +768,5 @@ TEST_CASE ("unsynchronized_pool_resource overhead limits", "[memory_resource]")
             resource.deallocate (ptr, numBytes, alignment);
     }
 }
+
+PMR_DIAGNOSTIC_POP


### PR DESCRIPTION
From AppleClang 15 and up classes in `std::experimental::pmr` are deprecated in favour of `std::pmr`. However `std::pmr` can only be used when the MacOS minimum version is 14 and up.

This PR sets `std::experimental::pmr` to continue being used when the MacOS minimum version is below 14. It also provides some helper macros to ignore the depreciated warnings.