### PR TITLE
Fix Apple SDK comparison

### DIFF
--- a/include/realtime_memory/pmr_includes.h
+++ b/include/realtime_memory/pmr_includes.h
@@ -4,28 +4,34 @@
 #include <vector>
 
 #if defined (__apple_build_version__)
- #define USE_EXPERIMENTAL_PMR __apple_build_version__ < 15000000 || __MAC_OS_X_VERSION_MIN_REQUIRED < 140000
-#elif defined (__clang__)
- #define USE_EXPERIMENTAL_PMR _LIBCPP_VERSION < 1600
+  #if (__apple_build_version__ < 1500000)
+    #define USE_EXPERIMENTAL_PMR 1
+  #elif defined (__MAC_OS_X_VERSION_MIN_REQUIRED) && (__MAC_OS_X_VERSION_MIN_REQUIRED < 101400)
+    #define USE_EXPERIMENTAL_PMR 1
+  #else
+    #define USE_EXPERIMENTAL_PMR 0
+  #endif
+#elif defined (__clang__) && (_LIBCPP_VERSION < 1600)
+  #define USE_EXPERIMENTAL_PMR 1
 #else
- #define USE_EXPERIMENTAL_PMR 0
+  #define USE_EXPERIMENTAL_PMR 0
 #endif
 
 #if USE_EXPERIMENTAL_PMR
- #include <experimental/memory_resource>
- namespace std_pmr = std::experimental::pmr;
+  #include <experimental/memory_resource>
+  namespace std_pmr = std::experimental::pmr;
 #else
- #include <memory_resource>
- namespace std_pmr = std::pmr;
+  #include <memory_resource>
+  namespace std_pmr = std::pmr;
 #endif
 
 #if defined (__apple_build_version__) && USE_EXPERIMENTAL_PMR
- #define PMR_DIAGNOSTIC_PUSH \
-  _Pragma("clang diagnostic push") \
-  _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
- #define PMR_DIAGNOSTIC_POP \
-  _Pragma("clang diagnostic pop")
+  #define PMR_DIAGNOSTIC_PUSH \
+     _Pragma("clang diagnostic push") \
+      _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+  #define PMR_DIAGNOSTIC_POP \
+     _Pragma("clang diagnostic pop")
 #else
- #define PMR_DIAGNOSTIC_PUSH
- #define PMR_DIAGNOSTIC_POP
+  #define PMR_DIAGNOSTIC_PUSH
+  #define PMR_DIAGNOSTIC_POP
 #endif

--- a/include/realtime_memory/pmr_includes.h
+++ b/include/realtime_memory/pmr_includes.h
@@ -1,7 +1,10 @@
 #include <algorithm>
 #include <atomic>
 #include <cassert>
+#include <stdexcept>
+#include <utility>
 #include <vector>
+
 
 #if defined (__apple_build_version__)
   #if (__apple_build_version__ < 1500000)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.12)
 Include(FetchContent)
 FetchContent_Declare(Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG        v3.0.1) # or a later release
+  GIT_TAG        v3.8.1) # or a later release
 FetchContent_MakeAvailable(Catch2)
 
 add_executable(realtime_memory_tests

--- a/tests/resource_tests.cpp
+++ b/tests/resource_tests.cpp
@@ -2,6 +2,8 @@
 // Copyright (c) 2019-2023 CradleApps, LLC - All Rights Reserved
 //==============================================================================
 
+#include <numeric>
+#include <random>
 #include <unordered_set>
 #include <unordered_map>
 


### PR DESCRIPTION
I think in the end I just messed up the constant we're comparing to `__MAC_OS_X_VERSION_MIN_REQUIRED`. 
`140000` should have been `101400`.

While I was here, I refactored the `#define`s a tiny bit to evaluate to plain 0s and 1s. I think this is better practice, because you aren't accidentally pasting tokens into places where they might not resolve properly.

And I added an extra space of indentation because the it made nested `#if`s easier to read.

Finally I had to make some fixes to the CI build - I guess Github actions has changed out the compiler on us.